### PR TITLE
Updated README and DNS settings for peer connections

### DIFF
--- a/docker-compose-admin.yml
+++ b/docker-compose-admin.yml
@@ -48,8 +48,9 @@ services:
       - TZ=America/New_York # Change to your timezone.
       - SERVERPORT=7000 # 
       - PEERS=1 # Number of client profiles.
-      - PEERDNS=1.1.1.1 # DNS when client is connected.
+      - PEERDNS=''
       - INTERNAL_SUBNET=12.6.0.0 # Subnet for all wireguard connections.
+      - ALLOWEDIPS=12.2.0.0/24 # Split tunnel only to local services (e.g. portainer)
     volumes:
       - wireguard-admin-volume:/config
       - /lib/modules:/lib/modules

--- a/docker-compose-private.yml
+++ b/docker-compose-private.yml
@@ -43,6 +43,7 @@ services:
       - PEERS=1 # Number of Client profiles (Change change this in portainer)
       - PEERDNS=10.2.0.100 # points to Pihole
       - INTERNAL_SUBNET=10.6.0.0 # Subnet for all wireguard connections.
+      - ALLOWEDIPS='10.6.0.0/24, 10.2.0.0/24' # To tunnel all network, remove this line.'
     volumes:
       - wireguard-private-volume:/config
       - /lib/modules:/lib/modules

--- a/docker-compose-private.yml
+++ b/docker-compose-private.yml
@@ -43,7 +43,7 @@ services:
       - PEERS=1 # Number of Client profiles (Change change this in portainer)
       - PEERDNS=10.2.0.100 # points to Pihole
       - INTERNAL_SUBNET=10.6.0.0 # Subnet for all wireguard connections.
-      - ALLOWEDIPS='10.6.0.0/24, 10.2.0.0/24' # To tunnel all network, remove this line.'
+      - ALLOWEDIPS=10.6.0.0/24, 10.2.0.0/24 # To tunnel all network, remove this line.'
     volumes:
       - wireguard-private-volume:/config
       - /lib/modules:/lib/modules


### PR DESCRIPTION
Peer connections can now connect to local network. Full tunneling is still an option in the peer configurations.